### PR TITLE
Potential fix for code scanning alert no. 6: Expression injection in Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,8 +6,11 @@ jobs:
     steps:
       - name: Get short commit message
         id: short_commit_message
+        env:
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          echo "SHORT_MESSAGE=$(echo '${{ github.event.head_commit.message }}' | tr -d '\n' | cut -c 1-50 | sed 's/[;&\`'\'']/ /g')" >> $GITHUB_ENV
+          SHORT_MESSAGE=$(echo "$HEAD_COMMIT_MESSAGE" | tr -d '\n' | cut -c 1-50 | sed 's/[;&`'\'']/ /g')
+          echo "SHORT_MESSAGE=$SHORT_MESSAGE" >> $GITHUB_ENV
       - uses: noweh/post-tweet-v2-action@v1.0
         with:
           message: |


### PR DESCRIPTION
Potential fix for [https://github.com/Unix-User/facechess/security/code-scanning/6](https://github.com/Unix-User/facechess/security/code-scanning/6)

To fix the issue, we need to ensure that the user-controlled input (`github.event.head_commit.message`) is handled securely. The best practice is to set the untrusted input to an intermediate environment variable and use shell syntax to reference the variable, avoiding direct interpolation of the input in the shell command. Additionally, we should ensure that the sanitization process is robust and covers all potential injection vectors.

Steps to fix:
1. Store the `github.event.head_commit.message` in an environment variable using GitHub Actions syntax.
2. Use shell syntax (`$VAR`) to reference the environment variable in the shell command.
3. Ensure that the sanitization process is robust and does not rely solely on `sed`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
