### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Unix-User/facechess/security/code-scanning/10](https://github.com/Unix-User/facechess/security/code-scanning/10)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow performs basic CI tasks (installing dependencies, building, and testing), it only requires `contents: read` permissions. This block should be added at the root level of the workflow to apply to all jobs unless overridden by job-specific permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
