### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: Notify twitter
 on: [push]
+permissions:
+  contents: read
 jobs:
   setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Unix-User/facechess/security/code-scanning/9](https://github.com/Unix-User/facechess/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not use the `GITHUB_TOKEN` for any write operations, we can set the permissions to `contents: read`, which is the minimal permission required for basic CI workflows. This ensures that the workflow adheres to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
